### PR TITLE
Fixed localStorage clear error

### DIFF
--- a/modules/core/src/storageinterruptsource.ts
+++ b/modules/core/src/storageinterruptsource.ts
@@ -14,7 +14,7 @@ export class StorageInterruptSource extends WindowInterruptSource {
    * @return True if the event should be filtered (don't cause an interrupt); otherwise, false.
    */
   filterEvent(event: StorageEvent): boolean {
-    if (event.key.indexOf('ng2Idle.') >= 0 && event.key.indexOf('.expiry') >= 0) {
+    if (event.key && event.key.indexOf('ng2Idle.') >= 0 && event.key.indexOf('.expiry') >= 0) {
       return false;
     }
     return true;


### PR DESCRIPTION
When localStorage of application is cleared manually on the fly, this will through console error since event.key === null. Hence added in a check if it exists as well.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/HackedByChinese/ng2-idle/blob/master/CONTRIBUTING.md#pr
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When localStorage is cleared manually from Application > LocalStorage > clear button, this will throw console error _TypeError: Cannot read property 'indexOf' of null_. 


**What is the new behavior?**
No console errors will be thrown from now.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
